### PR TITLE
[FIX] Use logger instead of logging to prevent overriding basicConfig

### DIFF
--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -90,7 +90,7 @@ class HiYaPyCo():
 
         self.method = None
         if 'method' in kwargs:
-            logging.debug('parse kwarg method: %s ...' % kwargs['method'])
+            logger.debug('parse kwarg method: %s ...' % kwargs['method'])
             if kwargs['method'] not in METHODS.values():
                 raise HiYaPyCoInvocationException(
                         'undefined method used, must be one of: %s' %


### PR DESCRIPTION
In Python when you call `logging.xxx()` before setting `logging.basicConfig` it will set the loglevel no matter what will be used afterwards. This was a miss I guess using `logging` instead of all other usages of `logger`. For me this version caused a major bug not showing our logs because I used `hiyapyco.load(.., loglevel='INFO')` before setting `logging.basicConfig`.