### PR TITLE
fix - dump with stream object

### DIFF
--- a/hiyapyco/odyldo.py
+++ b/hiyapyco/odyldo.py
@@ -75,5 +75,5 @@ def safe_load_all(stream):
 
 def safe_dump(data, stream=None, **kwds):
     """implementation of safe dumper using Ordered Dict Yaml Dumper"""
-    return yaml.dump(data, stream=None, Dumper=ODYD, **kwds)
+    return yaml.dump(data, stream=stream, Dumper=ODYD, **kwds)
 


### PR DESCRIPTION
the bug:
```
import io, hiyapyco
a = io.StringIO()
hiyapyco.dump({}, stream=a)  # actually returns the string `"{}\n"`
print(a.getvalue())  # prints nothing
```
after this fix it will work as expected, and the last row will print `{}\n`