### PR TITLE
Further fine-tuning of Debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Priority: optional
 Build-Depends: python3-setuptools,
                python3-all (>= 3.2.3-6),
                python3-setuptools,
-               python3-virtualenv,
+               python3-yaml,
+               python3-jinja2 <!nocheck>,
                dh-python,
                debhelper (>= 11)
 Standards-Version: 4.6.2
@@ -17,7 +18,7 @@ Rules-Requires-Root: no
 Package: python3-hiyapyco
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}
-Description: Hierarchical Yaml Python Config
+Description: Hierarchical YAML Python Config
  A simple python lib allowing hierarchical overlay of config files
  in YAML syntax, offering different merge methods and variable
  interpolation based on jinja2.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,12 +1,30 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Source: https://github.com/zerwes/hiyapyco
+Upstream-Name: HiYaPyCo
+
+Files: *
 Copyright: 2014 - 2022 Klaus Zerwes zero-sys.net
+License: GPL-3.0+
 
-License:
+Files:
+ debian/*
+Copyright: 2014 - 2022 Klaus Zerwes zero-sys.net
+           2022 Updates by Steffen Moeller <moeller@debian.org>
+License: GPL-3.0+
 
-   This package is free software.  
-   This software is licensed under the terms of the
-   GNU GENERAL PUBLIC LICENSE version 3 or later,
-   as published by the Free Software Foundation.  
-
-   A copy of the license is included here:
-   /usr/share/common-licenses/GPL
-
+License: GPL-3.0+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+Comment:
+ On Debian systems, the complete text of the GNU General
+ Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,8 @@
 #!/usr/bin/make -f
 
-PACKAGE_PYTHON3=python3-hiyapyco
-
 %:
 	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_clean:
-	rm -rf HiYaPyCo.egg-info
+	rm -rf HiYaPyCo.egg-info dist
 	dh_auto_clean


### PR DESCRIPTION
Many thanks for your prior positive reaction to what I did to debian/*. Ping me if you would like to maintain the package in Debian yourself. To avoid going through PRs and to grant more folks the opportunity to further improve on the packaging, I would like to bring the package under team management on https://salsa.debian.org/python-team.

Next step in the development of the packaging would be the integration of your testing routines with what salsa offers - later :)