### PR TITLE
Update __init__.py to remove distutils deprecated dependence

### DIFF
--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -22,7 +22,6 @@ from __future__ import unicode_literals
 import sys
 import os
 import logging
-from distutils.util import strtobool
 import re
 import io
 import yaml
@@ -520,5 +519,14 @@ def load(*args, **kwargs):
     """
     hiyapyco = HiYaPyCo(*args, **kwargs)
     return hiyapyco.data()
+
+def strtobool(val):
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent nu

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -521,12 +521,14 @@ def load(*args, **kwargs):
     return hiyapyco.data()
 
 def strtobool(val):
+    """
+    minimal implementation of the strtobool function (replaces deprecated distutils)
+    """
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
         return 1
-    elif val in ("n", "no", "f", "false", "off", "0"):
+    if val in ("n", "no", "f", "false", "off", "0"):
         return 0
-    else:
-        raise ValueError("invalid truth value %r" % (val,))
+    raise ValueError("invalid truth value %r" % (val,))
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent nu


### PR DESCRIPTION
Removed [deprecated](https://docs.python.org/3.10/library/distutils.html) `strtobool` import and added own implementation stated on #61.