### PR TITLE
Allow custom yaml loaders as callback functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 # PyCharm
 .idea
+# vscode
+.vscode
 
 build
 HiYaPyCo.egg-info

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -19,15 +19,13 @@ See https://www.gnu.org/licenses/gpl.html
 
 from __future__ import unicode_literals
 
-import sys
 import os
 import logging
 import re
 import io
 import copy
 import yaml
-from yaml import parser
-from jinja2 import Environment, Undefined, DebugUndefined, StrictUndefined, TemplateError
+from jinja2 import Environment, Undefined, TemplateError
 
 from . import odyldo
 
@@ -88,6 +86,8 @@ class HiYaPyCo:
           * failonmissingfiles: boolean (default: True)
           * loglevelmissingfiles
           * mergeoverride: optional function to customize merge for primitive values
+          * loader_callback: optional custom callback function to load yaml files. The callback function shall
+            behave like `yaml.load_all`, taking a IO stream as input and returning a list of objects.
 
         Returns a representation of the merged and (if requested) interpolated config.
         Will mostly be a OrderedDict (dict if usedefaultyamlloader), but can be of any other type,
@@ -97,6 +97,8 @@ class HiYaPyCo:
         self._files = []
 
         self.method = None
+        self.loader_callback = kwargs.pop("loader_callback", None)
+
         if 'method' in kwargs:
             logger.debug('parse kwarg method: %s ...' % kwargs['method'])
             if kwargs['method'] not in METHODS.values():
@@ -247,7 +249,9 @@ class HiYaPyCo:
             self._data = self._interpolate(self._data)
 
     def _load_data(self, _USEDEFAULTYAMLLOADER, f):
-        if _USEDEFAULTYAMLLOADER:
+        if self.loader_callback is not None:
+            ydata_generator = self.loader_callback(f)
+        elif _USEDEFAULTYAMLLOADER:
             ydata_generator = yaml.safe_load_all(f)
         else:
             ydata_generator = odyldo.safe_load_all(f)

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -86,8 +86,9 @@ class HiYaPyCo:
           * failonmissingfiles: boolean (default: True)
           * loglevelmissingfiles
           * mergeoverride: optional function to customize merge for primitive values
-          * loader_callback: optional custom callback function to load yaml files. The callback function shall
-            behave like `yaml.load_all`, taking a IO stream as input and returning a list of objects.
+          * loader_callback: optional custom callback function to load yaml files. The
+            callback function shall behave like `yaml.load_all`, taking a IO stream as
+            input and returning a list of objects.
 
         Returns a representation of the merged and (if requested) interpolated config.
         Will mostly be a OrderedDict (dict if usedefaultyamlloader), but can be of any other type,

--- a/test/test_custom_yaml_loader.py
+++ b/test/test_custom_yaml_loader.py
@@ -1,0 +1,42 @@
+#! /usr/bin/env python
+
+import sys
+import os
+import logging
+import platform
+import hiyapyco
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0]))), "lib"
+    ),
+)
+import testsetup
+
+logger = testsetup.setup(sys.argv[1:])
+
+basepath = os.path.dirname(os.path.realpath(__file__))
+
+print(
+    "start test %s for hiyapyco %s using python %s (loglevel:%s)"
+    % (
+        __file__,
+        hiyapyco.__version__,
+        platform.python_version(),
+        logging.getLevelName(logger.getEffectiveLevel()),
+    )
+)
+
+logger.info("test custom yaml loader ...")
+
+
+def custom_loader(stream):
+    """Mock loader that doesn't actually read the yaml file"""
+    return [{"custom_yaml": 42}]
+
+
+conf = hiyapyco.load(os.path.join(basepath, "base.yaml"), loader_callback=custom_loader)
+assert conf == {"custom_yaml": 42}
+
+print("passed test %s" % __file__)


### PR DESCRIPTION
This PR adds an additional argument `loader_callback` to hiyapyco that allows to specify custom yaml loader functions. 

Close #74
Close #68 
Close #57 (ruamel can trivially be specified as custom callback)

