### PR TITLE
Implement none-behavior strategies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ kwargs
 - ``none_behavior``: bit (one of the listed below):
 
    -  ``hiyapyco.NONE_BEHAVIOR_DEFAULT``: attempt to merge the value with ``None`` and fail if this is not possible (default method)
-   -  ``hiyapyco.NONE_BEHAVIOR_OVERRIDE``: ``None`` always overrides any other value.  
+   -  ``hiyapyco.NONE_BEHAVIOR_OVERRIDE``: ``None`` always overrides any other value.
 
 -  ``interpolate``: boolean : perform interpolation after the merge
    (default: ``False``)

--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,11 @@ kwargs
 
 - ``mergelists``: boolean try to merge lists of dict (default: ``True``)
 
+- ``none_behavior``: bit (one of the listed below):
+
+   -  ``hiyapyco.NONE_BEHAVIOR_DEFAULT``: attempt to merge the value with ``None`` and fail if this is not possible (default method)
+   -  ``hiyapyco.NONE_BEHAVIOR_OVERRIDE``: ``None`` always overrides any other value.  
+
 -  ``interpolate``: boolean : perform interpolation after the merge
    (default: ``False``)
 

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -463,6 +463,7 @@ class HiYaPyCo:
                 return None
             # default behavior is to attempt merge or fail
             logger.debug('pass as b is None')
+            pass
         if a is None or isinstance(b, primitiveTypes):
             if self.mergeprimitive is None:
                 logger.debug('deepmerge: replace a "%s"  w/ b "%s"' % (a, b,))

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -345,23 +345,14 @@ class HiYaPyCo:
         if self.dereferenceyamlanchors:
             a = copy.deepcopy(a)
             b = copy.deepcopy(b)
-        logger.debug(
-            "simplemerge %s (%s) and %s (%s)"
-            % (
-                a,
-                type(a),
-                b,
-                type(b),
-            )
-        )
+        logger.debug('simplemerge %s (%s) and %s (%s)' % (a, type(a), b, type(b),))
         if b is None:
-            logger.debug('pass as b is None')
             # override -> None replaces object, no matter what.
             if self.none_behavior == NONE_BEHAVIOR_OVERRIDE:
+                logger.debug('b is None + none_behavior in use => return None')
                 return None
             # default behavior is to attempt merge or fail
-            else:
-                pass
+            logger.debug('pass as b is None')
         elif isinstance(b, primitiveTypes):
             logger.debug('simplemerge: primitiveTypes replace a "%s"  w/ b "%s"' % (a, b,))
             a = b
@@ -396,21 +387,15 @@ class HiYaPyCo:
             a = copy.deepcopy(a)
             b = copy.deepcopy(b)
         logger.debug('>' * 30)
-        logger.debug(
-            "substmerge %s and %s"
-            % (
-                a,
-                b,
-            )
-        )
+        logger.debug('substmerge %s and %s' % (a, b,))
+        # FIXME: make None usage configurable
         if b is None:
             logger.debug('pass as b is None')
             # override -> None replaces object, no matter what.
             if self.none_behavior == NONE_BEHAVIOR_OVERRIDE:
+                logger.debug('b is None + none_behavior in use => return None')
                 return None
             # default behavior is to attempt merge or fail
-            else:
-                pass
 
         # treat listTypes as primitiveTypes in merge
         # subsititues list, don't merge them
@@ -461,13 +446,8 @@ class HiYaPyCo:
         if self.dereferenceyamlanchors:
             a = copy.deepcopy(a)
             b = copy.deepcopy(b)
-        logger.debug(
-            "deepmerge %s and %s"
-            % (
-                a,
-                b,
-            )
-        )
+        logger.debug('deepmerge %s and %s' % (a, b,))
+        # FIXME: make None usage configurable
         if b is None:
             logger.debug('pass as b is None')
             # override -> None replaces object, no matter what.

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -396,6 +396,7 @@ class HiYaPyCo:
                 logger.debug('b is None + none_behavior in use => return None')
                 return None
             # default behavior is to attempt merge or fail
+            logger.debug('pass as b is None')
 
         # treat listTypes as primitiveTypes in merge
         # subsititues list, don't merge them
@@ -454,8 +455,7 @@ class HiYaPyCo:
             if self.none_behavior == NONE_BEHAVIOR_OVERRIDE:
                 return None
             # default behavior is to attempt merge or fail
-            else:
-                pass
+            logger.debug('pass as b is None')
         if a is None or isinstance(b, primitiveTypes):
             if self.mergeprimitive is None:
                 logger.debug('deepmerge: replace a "%s"  w/ b "%s"' % (a, b,))

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -403,6 +403,7 @@ class HiYaPyCo:
                 return None
             # default behavior is to attempt merge or fail
             logger.debug('pass as b is None')
+            pass
 
         # treat listTypes as primitiveTypes in merge
         # subsititues list, don't merge them

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -67,6 +67,10 @@ METHOD_SIMPLE = METHODS['METHOD_SIMPLE']
 METHOD_MERGE = METHODS['METHOD_MERGE']
 METHOD_SUBSTITUTE = METHODS['METHOD_SUBSTITUTE']
 
+NONE_BEHAVIORS = {"NONE_BEHAVIOR_DEFAULT": 0x0001, "NONE_BEHAVIOR_OVERRIDE": 0x0002}
+NONE_BEHAVIOR_DEFAULT = NONE_BEHAVIORS["NONE_BEHAVIOR_DEFAULT"]
+NONE_BEHAVIOR_OVERRIDE = NONE_BEHAVIORS["NONE_BEHAVIOR_OVERRIDE"]
+
 
 class HiYaPyCo:
     """Main class"""
@@ -79,6 +83,7 @@ class HiYaPyCo:
             hiyapyco.METHOD_SIMPLE | hiyapyco.METHOD_MERGE | hiyapyco.METHOD_SUBSTITUTE
           * mergelists: boolean (default: True) try to merge lists
             (only makes sense if hiyapyco.METHOD_MERGE or hiyapyco.METHOD_SUBSTITUTE)
+          * none_behavior: one of hiyapyco.NONE_BEHAVIOR_DEFAULT | hiyapyco.NONE_BEHAVIOR_OVERRIDE
           * interpolate: boolean (default: False)
           * castinterpolated: boolean (default: False) try to cast values after interpolating
           * usedefaultyamlloader: boolean (default: False)
@@ -118,6 +123,19 @@ class HiYaPyCo:
                         )
             self.mergelists = kwargs['mergelists']
             del kwargs['mergelists']
+
+        self.none_behavior = None
+        if "none_behavior" in kwargs:
+            logger.debug("parse kwarg method: %s ..." % kwargs["none_behavior"])
+            if kwargs["none_behavior"] not in NONE_BEHAVIORS.values():
+                raise HiYaPyCoInvocationException(
+                    "undefined method used, must be one of: %s"
+                    % " ".join(NONE_BEHAVIORS.keys())
+                )
+            self.none_behavior = kwargs["none_behavior"]
+            del kwargs["none_behavior"]
+        if self.none_behavior is None:
+            self.none_behavior = NONE_BEHAVIOR_DEFAULT
 
         self.interpolate = False
         self.castinterpolated = False
@@ -327,11 +345,23 @@ class HiYaPyCo:
         if self.dereferenceyamlanchors:
             a = copy.deepcopy(a)
             b = copy.deepcopy(b)
-        logger.debug('simplemerge %s (%s) and %s (%s)' % (a, type(a), b, type(b),))
-        # FIXME: make None usage configurable
+        logger.debug(
+            "simplemerge %s (%s) and %s (%s)"
+            % (
+                a,
+                type(a),
+                b,
+                type(b),
+            )
+        )
         if b is None:
             logger.debug('pass as b is None')
-            pass
+            # override -> None replaces object, no matter what.
+            if self.none_behavior == NONE_BEHAVIOR_OVERRIDE:
+                return None
+            # default behavior is to attempt merge or fail
+            else:
+                pass
         elif isinstance(b, primitiveTypes):
             logger.debug('simplemerge: primitiveTypes replace a "%s"  w/ b "%s"' % (a, b,))
             a = b
@@ -366,11 +396,21 @@ class HiYaPyCo:
             a = copy.deepcopy(a)
             b = copy.deepcopy(b)
         logger.debug('>' * 30)
-        logger.debug('substmerge %s and %s' % (a, b,))
-        # FIXME: make None usage configurable
+        logger.debug(
+            "substmerge %s and %s"
+            % (
+                a,
+                b,
+            )
+        )
         if b is None:
             logger.debug('pass as b is None')
-            pass
+            # override -> None replaces object, no matter what.
+            if self.none_behavior == NONE_BEHAVIOR_OVERRIDE:
+                return None
+            # default behavior is to attempt merge or fail
+            else:
+                pass
 
         # treat listTypes as primitiveTypes in merge
         # subsititues list, don't merge them
@@ -421,11 +461,21 @@ class HiYaPyCo:
         if self.dereferenceyamlanchors:
             a = copy.deepcopy(a)
             b = copy.deepcopy(b)
-        logger.debug('deepmerge %s and %s' % (a, b,))
-        # FIXME: make None usage configurable
+        logger.debug(
+            "deepmerge %s and %s"
+            % (
+                a,
+                b,
+            )
+        )
         if b is None:
             logger.debug('pass as b is None')
-            pass
+            # override -> None replaces object, no matter what.
+            if self.none_behavior == NONE_BEHAVIOR_OVERRIDE:
+                return None
+            # default behavior is to attempt merge or fail
+            else:
+                pass
         if a is None or isinstance(b, primitiveTypes):
             if self.mergeprimitive is None:
                 logger.debug('deepmerge: replace a "%s"  w/ b "%s"' % (a, b,))

--- a/hiyapyco/__init__.py
+++ b/hiyapyco/__init__.py
@@ -358,6 +358,7 @@ class HiYaPyCo:
                 return None
             # default behavior is to attempt merge or fail
             logger.debug('pass as b is None')
+            pass
         elif isinstance(b, primitiveTypes):
             logger.debug('simplemerge: primitiveTypes replace a "%s"  w/ b "%s"' % (a, b,))
             a = b

--- a/test/base_none_behavior.yaml
+++ b/test/base_none_behavior.yaml
@@ -1,15 +1,15 @@
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent
-singel: null 
-int: null 
+singel: null
+int: null
 array: null
 hash: null
 deeplist:
     - d1: null
     - d2:
-        d2k1: null 
+        d2k1: null
         d2k2: x2
 deepmap:
     l1k1:
-        l2k1: null 
+        l2k1: null
         l2k2: abc
     l1k2: null

--- a/test/base_none_behavior.yaml
+++ b/test/base_none_behavior.yaml
@@ -1,0 +1,15 @@
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent
+singel: null 
+int: null 
+array: null
+hash: null
+deeplist:
+    - d1: null
+    - d2:
+        d2k1: null 
+        d2k2: x2
+deepmap:
+    l1k1:
+        l2k1: null 
+        l2k2: abc
+    l1k2: null

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -173,6 +173,65 @@ try:
 except KeyError as e:
     assert '%s' % e == '\'nosuchelement\''
 
-print('passed test %s' % __file__)
+
+logger.info("test none behavior DEFAULT ...")
+for method in [hiyapyco.METHOD_MERGE, hiyapyco.METHOD_SUBSTITUTE]:
+    try:
+        conf = hiyapyco.load(
+            os.path.join(basepath, "base.yaml"),
+            os.path.join(basepath, "base_none_behavior.yaml"),
+            method=method,
+            failonmissingfiles=True,
+        )
+    except hiyapyco.HiYaPyCoImplementationException:
+        pass
+    else:
+        raise AssertionError("Default None behavior is expected to fail on this merge")
+
+logger.info("test none behavior OVERRIDE ...")
+for method in hiyapyco.METHODS.values():
+    conf = hiyapyco.load(
+        os.path.join(basepath, "base.yaml"),
+        os.path.join(basepath, "base_none_behavior.yaml"),
+        none_behavior=hiyapyco.NONE_BEHAVIOR_OVERRIDE,
+        method=hiyapyco.METHOD_MERGE,
+        failonmissingfiles=True,
+    )
+
+    t = conf["singel"]
+    logger.info("test single val ... %s" % t)
+    assert t is None
+
+    t = conf["int"]
+    logger.info("test int val ... %s" % t)
+    assert t is None
+
+    t = conf["array"]
+    logger.info("test list val ... %s" % t)
+    assert t is None
+
+    t = conf["hash"]
+    logger.info("test simple dict ... %s" % t)
+    assert t is None
+
+    t = conf["deeplist"]
+    logger.info("test deeplist ... %s" % t)
+    assert t == [
+        {"d1": None},
+        {"d2": {"d2k2": "x2", "d2k1": None}},
+        {
+            "d32": {"a": "A2", "b": "B2"},
+            "d31": {"a": "A", "c": "C", "b": "B"},
+        },
+    ]
+
+    t = conf["deepmap"]
+    logger.info("test deepmap ... %s" % t)
+    assert t == {
+        "l1k1": {"l2k1": None, "l2k2": "abc"},
+        "l1k2": None,
+    }
+
+print("passed test %s" % __file__)
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 smartindent nu


### PR DESCRIPTION
This PR adds a new option `none_behavior` that allows to specify different strategies for handling `None` values. 
For now there are only two strategies implemented 
 * `NONE_BEHAVIOR_DEFAULT` -> attempt to merge or fail (previous hyapyco behavior)
 * `NONE_BEHAVIOR_OVERRIDE` -> `None` overrides the existing value, independent of the merge strategy. 

Other strategies could be implemented in the future such as ignoring None values. 